### PR TITLE
Add Mac App Store download link to Uplink hero section

### DIFF
--- a/apps/uplink/index.html
+++ b/apps/uplink/index.html
@@ -33,6 +33,7 @@
             <h1>Uplink</h1>
             <p class="lead">Know when your internet is the problem.</p>
             <p class="tagline">A native macOS menu bar app that quietly watches your connection. When latency spikes or packets start dropping, it's the first thing to tell you — before your Zoom call stutters, before your game rubber-bands, before you waste an hour blaming the other end.</p>
+            <p class="app-store"><a href="https://apps.apple.com/us/app/uplink-network-monitor/id6762632231?mt=12">Download on the Mac App Store</a></p>
             <p class="requirements">Requires macOS 13 Ventura or newer. Apple Silicon or Intel.</p>
         </div>
 

--- a/apps/uplink/uplink.css
+++ b/apps/uplink/uplink.css
@@ -27,6 +27,24 @@
     color: #555;
 }
 
+#hero .app-store {
+    margin: 24px auto 0;
+}
+
+#hero .app-store a {
+    display: inline-block;
+    padding: 10px 22px;
+    background-color: #000;
+    color: #fff;
+    border-radius: 8px;
+    font-weight: 500;
+    text-decoration: none;
+}
+
+#hero .app-store a:hover {
+    background-color: #222;
+}
+
 #hero .requirements {
     font-size: 0.9rem;
     color: #888;


### PR DESCRIPTION
## Summary
Added a prominent "Download on the Mac App Store" link to the Uplink landing page hero section, along with corresponding styling to match the app's design.

## Changes
- **HTML**: Added a new paragraph with a link to the Uplink app on the Mac App Store (app ID: 6762632231)
- **CSS**: Added styling for the app store link container and button:
  - Container margins for proper spacing below the tagline
  - Button styling with black background, white text, rounded corners, and hover effect
  - Hover state changes background to a lighter shade (#222) for visual feedback

## Implementation Details
- The link is positioned between the tagline and system requirements text
- The button uses a clean, minimal design consistent with modern app marketing
- Hover state provides clear interactive feedback to users
- Link targets macOS 12+ version of the app on Apple's App Store

https://claude.ai/code/session_01ForQUh2sqgTZza6AuNoMGp