### PR TITLE
Rename homepage link labels to friendly names

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         </div>
         
         <div id="bio">
-            <p>Hi, I’m Matt. 👋 I’m a Technical Product Management leader at Microsoft, focused on hyperscale cloud infrastructure. I’m also a builder at heart — I write code, ship side projects, and care a lot about creating environments where people can do their best work.</p>
+            <p>Hi, I’m Matt. 👋 I’m a Technical Product Management leader at Microsoft. I specialize in hyperscale cloud infrastructure operations and automation. I’m also a builder at heart — I write code, ship side projects, and care a lot about creating environments where people can do their best work.</p>
         </div>
 
         <div id="contact">

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         </div>
         
         <div id="bio">
-            <p>Hi, I'm Matt. 👋 I'm a Technical Product Management Leader at Microsoft. I specialize in cloud infrastructure and systems innovation. I'm passionate about building high-performing teams, creating environments where everyone can do their best work, and helping others succeed.</p>
+            <p>Hi, I’m Matt. 👋 I’m a Technical Product Management leader at Microsoft, focused on hyperscale cloud infrastructure. I’m also a builder at heart — I write code, ship side projects, and care a lot about creating environments where people can do their best work.</p>
         </div>
 
         <div id="contact">

--- a/index.html
+++ b/index.html
@@ -30,10 +30,10 @@
 
         <div id="contact">
             <p>You can contact me directly, or find me online at the links below:</p>
-            <p><a href="mailto:matt@mbmccormick.com" target="_blank">matt@mbmccormick.com</a></p>
-            <p><a href="https://linkedin.com/in/mbmccorm" target="_blank">linkedin.com/in/mbmccorm</a></p>
-            <p><a href="https://github.com/mbmccormick" target="_blank">github.com/mbmccormick</a></p>
-            <p><a href="https://apps.apple.com/us/developer/matthew-mccormick/id1894897968" target="_blank">apps.apple.com</a></p>
+            <p><a href="mailto:matt@mbmccormick.com" target="_blank">Email</a></p>
+            <p><a href="https://linkedin.com/in/mbmccorm" target="_blank">LinkedIn</a></p>
+            <p><a href="https://github.com/mbmccormick" target="_blank">GitHub</a></p>
+            <p><a href="https://apps.apple.com/us/developer/matthew-mccormick/id1894897968" target="_blank">App Store</a></p>
         </div>
 
     </div>


### PR DESCRIPTION
Replaces raw URLs/email with concise labels (Email, LinkedIn, GitHub,
App Store) for cleaner presentation.